### PR TITLE
Updates for latest Rubocop and Chef

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ gem 'foodcritic', '~> 3.0'
 gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
 
+gem 'chef', '< 12.0'
+
 gem 'rubocop'
 gem 'rubocop-checkstyle_formatter', require: false
 gem 'rainbow', '<= 1.99.1'

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -32,7 +32,7 @@ end
   next unless node['coopr'].key?(sitefile)
   my_vars = { :options => node['coopr'][sitefile] }
 
-  template "#{coopr_conf_dir}/#{sitefile.gsub('_', '-')}.xml" do
+  template "#{coopr_conf_dir}/#{sitefile.tr('_', '-')}.xml" do
     source 'generic-site.xml.erb'
     mode '0644'
     owner 'root'


### PR DESCRIPTION
This restricts the Chef version for testing to < 12 as Chef 12 requires Ruby 2.0+