### PR TITLE
Remove MySQL for Derby for testing

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,7 +18,6 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[mysql::server]
       - recipe[hadoop::zookeeper]
       - recipe[coopr::fullstack]
       - recipe[minitest-handler::default]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,7 +53,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     chef.run_list = [
       'recipe[minitest-handler::default]',
       'recipe[hadoop::zookeeper_server]',
-      'recipe[mysql::server]',
       'recipe[coopr::fullstack]'
     ]
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs/Configures Coopr'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 
-%w(apt hadoop java mysql yum).each do |cb|
+%w(apt hadoop java yum).each do |cb|
   depends cb
 end
 


### PR DESCRIPTION
There's no need for MySQL, since we do not configure it. We use Derby for testing, so remove `mysql` from cookbook dependencies, `.kitchen.yml` and `Vagrantfile`.