### PR TITLE
Remove ZooKeeper as we use embedded for testing

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,7 +18,5 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[hadoop::zookeeper]
       - recipe[coopr::fullstack]
       - recipe[minitest-handler::default]
-    attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.1' } }

--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@
 [![Cookbook Version](http://img.shields.io/cookbook/v/coopr.svg)](https://supermarket.getchef.com/cookbooks/coopr)
 [![Build Status](http://img.shields.io/travis/caskdata/coopr_cookbook.svg)](http://travis-ci.org/caskdata/coopr_cookbook)
 
-# Requirements
+## Requirements
 
-* Oracle Java JDK 6+ (provided by `java` cookbook)
+* Oracle Java JDK 6+ (JDK 7 provided by `java` cookbook)
+
+## Optional dependencies
+
 * ZooKeeper (provided by `hadoop` cookbook)
 * JDBC-compatible database
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,7 +52,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     chef.run_list = [
       'recipe[minitest-handler::default]',
-      'recipe[hadoop::zookeeper_server]',
       'recipe[coopr::fullstack]'
     ]
   end

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: coopr
 # Attribute:: config
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,8 +25,12 @@ default['coopr']['user'] = 'coopr'
 default['coopr']['group'] = 'coopr'
 
 # coopr-site.xml
-# default['coopr']['coopr_site']['server.zookeeper.quorum'] = 'localhost:2181'
 default['coopr']['coopr_site']['server.host'] = '127.0.0.1'
+
+# Set the following property to use an external ZooKeeper quorum:
+# default['coopr']['coopr_site']['server.zookeeper.quorum'] = 'localhost:2181'
+
+# Set the following attribtues to use an external MySQL (or PostgreSQL, see docs for supported RDBMS)
 # default['coopr']['coopr_site']['server.jdbc.driver'] = 'com.mysql.jdbc.Driver'
 # default['coopr']['coopr_site']['server.jdbc.connection.string'] = 'jdbc:mysql://127.0.0.1:3306/coopr?useLegacyDatetimeCode=false'
 # default['coopr']['coopr_site']['server.db.user'] = 'coopr'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs/Configures Coopr'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 
-%w(apt hadoop java yum).each do |cb|
+%w(apt java yum).each do |cb|
   depends cb
 end
 


### PR DESCRIPTION
The cookbook isn't configured to use an external ZooKeeper, by default. If the user chooses to use an external ZooKeeper, they should be responsible for making it available using the `hadoop::zookeeper_server` recipe, or via other means.