### PR TITLE
Minor updates

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,4 +19,3 @@ suites:
   - name: default
     run_list:
       - recipe[coopr::fullstack]
-      - recipe[minitest-handler::default]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,7 +10,7 @@ provisioner:
   require_chef_omnibus: true
 
 platforms:
-  - name: centos-6.5
+  - name: centos-6.6
   - name: ubuntu-12.04
     run_list:
     - apt::default

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@
 language: ruby
 rvm:
   - 1.9.3
+  - 2.0.0
+  - 2.1.4
 cache: bundler
 sudo: false
 bundler_args: --jobs 7 --without docs integration

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,3 @@
 source 'https://supermarket.chef.io'
 
-group :integration do
-  cookbook 'minitest-handler'
-end
-
 metadata

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,20 @@
 source 'https://rubygems.org'
 
 gem 'berkshelf', '~> 3.0'
-gem 'foodcritic', '~> 3.0'
+gem 'foodcritic', '~> 4.0'
 
 gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
 
-gem 'chef', '< 12.0'
+if RUBY_VERSION.to_f < 2.0
+  gem 'chef', '< 12.0'
+  gem 'varia_model', '< 0.5.0'
+else
+  gem 'chef', '< 12.5' # Testing
+end
+
+gem 'ridley', '~> 4.2.0'
+gem 'faraday', '< 0.9.2'
 
 gem 'rubocop'
 gem 'rubocop-checkstyle_formatter', require: false

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -38,6 +38,6 @@ default['coopr']['coopr_site']['server.host'] = '127.0.0.1'
 # default['coopr']['coopr_site']['server.jdbc.validation.query'] = 'SELECT 1'
 
 # provisioner-site.xml
-default['coopr']['provisioner_site']['provisioner.server.uri'] = 'http://127.0.0.1:55054'
+default['coopr']['provisioner_site']['provisioner.server.uri'] = 'http://127.0.0.1:55055'
 default['coopr']['provisioner_site']['provisioner.register.ip'] = '127.0.0.1'
 default['coopr']['provisioner_site']['provisioner.log.level'] = 'info'

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -20,7 +20,7 @@
 case node['platform_family']
 when 'debian'
   include_recipe 'apt'
-  apt_repository 'cask' do
+  apt_repository 'coopr' do
     uri node['coopr']['repo']['apt_repo_url']
     distribution node['lsb']['codename']
     components node['coopr']['repo']['apt_components']
@@ -30,8 +30,8 @@ when 'debian'
   end
 when 'rhel'
   include_recipe 'yum'
-  yum_repository 'cask' do
-    description 'Cask YUM repository'
+  yum_repository 'coopr' do
+    description 'Coopr YUM repository'
     url node['coopr']['repo']['yum_repo_url']
     gpgkey "#{node['coopr']['repo']['yum_repo_url']}/pubkey.gpg"
     gpgcheck true

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe 'coopr::config' do
-  context 'on Centos 6.5 x86_64' do
+  context 'on Centos 6.6 x86_64' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
         stub_command('update-alternatives --display coopr-conf | grep best | awk \'{print $5}\' | grep /etc/coopr/conf.chef').and_return(false)
       end.converge(described_recipe)

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe 'coopr::default' do
-  context 'on Centos 6.5 x86_64' do
+  context 'on Centos 6.6 x86_64' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
         stub_command('update-alternatives --display coopr-conf | grep best | awk \'{print $5}\' | grep /etc/coopr/conf.chef').and_return(false)
       end.converge(described_recipe)

--- a/spec/provisioner_spec.rb
+++ b/spec/provisioner_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe 'coopr::provisioner' do
-  context 'on Centos 6.5 x86_64' do
+  context 'on Centos 6.6 x86_64' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
         stub_command('update-alternatives --display coopr-conf | grep best | awk \'{print $5}\' | grep /etc/coopr/conf.chef').and_return(false)
       end.converge(described_recipe)

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -8,8 +8,8 @@ describe 'coopr::repo' do
       end.converge(described_recipe)
     end
 
-    it 'adds cask yum_repository' do
-      expect(chef_run).to add_yum_repository('cask')
+    it 'adds coopr yum_repository' do
+      expect(chef_run).to add_yum_repository('coopr')
     end
   end
   context 'on Ubuntu 12.0.4' do
@@ -19,8 +19,8 @@ describe 'coopr::repo' do
       end.converge(described_recipe)
     end
 
-    it 'adds cask apt_repository' do
-      expect(chef_run).to add_apt_repository('cask')
+    it 'adds coopr apt_repository' do
+      expect(chef_run).to add_apt_repository('coopr')
     end
   end
 end

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe 'coopr::repo' do
-  context 'on Centos 6.5 x86_64' do
+  context 'on Centos 6.6 x86_64' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
       end.converge(described_recipe)
     end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe 'coopr::server' do
-  context 'on Centos 6.5 x86_64' do
+  context 'on Centos 6.6 x86_64' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
         stub_command('update-alternatives --display coopr-conf | grep best | awk \'{print $5}\' | grep /etc/coopr/conf.chef').and_return(false)
       end.converge(described_recipe)

--- a/spec/ui_spec.rb
+++ b/spec/ui_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe 'coopr::ui' do
-  context 'on Centos 6.5 x86_64' do
+  context 'on Centos 6.6 x86_64' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
       end.converge(described_recipe)
     end


### PR DESCRIPTION
This pulls some changes from caskdata/cdap_cookbook and tries to bring this cookbook closer in line with that one, as far as testing is concerned.

- Update Gemfile for multiple Chef/Ruby versions
- Remove unused `minitest-handler` cookbook dependencies
- Fix `provisioner.server.uri` for Coopr Server 0.9.9
- Rename repo to `coopr` from `cask`
- Testing updates