### PR TITLE
Update rubocop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,30 @@
 Encoding:
   Enabled: False
 LineLength:
-  Max: 250
+  Max: 600
 Documentation:
   Enabled: False
 HashSyntax:
   Enabled: False
+AsciiComments:
+  Enabled: false
+Metrics/AbcSize:
+  Enabled: false
+Metrics/BlockLength:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/MethodLength:
+  Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  Enabled: false
 Style/SpaceBeforeFirstArg:
   Enabled: false
-AsciiComments:
+Style/SymbolArray:
   Enabled: false


### PR DESCRIPTION
Sync with caskdata/cdap_cookbook (except HashSyntax, that can come in another PR).

I'll merge this once the tests pass, since there's no actual cookbook code changes.