### PR TITLE
COOK-123 Add amazon to rhel platform_family conditional

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: coopr
 # Recipe:: repo
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ when 'debian'
     arch 'amd64'
     key "#{node['coopr']['repo']['apt_repo_url']}/pubkey.gpg"
   end
-when 'rhel'
+when 'rhel', 'amazon' # ~FC024
   include_recipe 'yum'
   yum_repository 'coopr' do
     description 'Coopr YUM repository'


### PR DESCRIPTION
This is needed for Chef 13 compatibility on Amazon Linux.