### PR TITLE
Version bump to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,21 @@
 * JDBC-compatible database (MySQL, PostgreSQL, Oracle DB)
 * JDBC driver JARs
 
-# Usage
+## Usage
 
 This cookbook is designed to install [Coopr](http://coopr.io) using the built-in ZooKeeper and Derby. A full installation
 simply needs the `coopr::fullstack` recipe to be included in your server's run_list.
 
-# Attributes
+### Attributes
 
 * `['coopr']['conf_dir']` - The directory used inside `/etc/coopr` and used via the alternatives system. Default `conf.chef`
 * `['coopr']['repo']['yum_repo_url']` - Specifies URL for fetching RPM packages via YUM
 * `['coopr']['repo']['apt_repo_url']` - Specifies URL for fetching DEB packages via APT
 * `['coopr']['repo']['apt_components']` - Repository components to use for APT repositories
 
-# Recipes
+### Recipes
 
+* `cli` - Installs the `coopr-cli` package
 * `config` - Configures all services
 * `default` - Runs `config` and `repo` recipes
 * `fullstack` - Installs all packages and services on a single node
@@ -37,11 +38,11 @@ simply needs the `coopr::fullstack` recipe to be included in your server's run_l
 * `server` - Installs the `coopr-server` package and service
 * `ui` - Installs the `coopr-ui` package and service
 
-# Author
+## Author
 
 Author:: Cask Data, Inc. (<ops@cask.co>)
 
-# License
+## License
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this software except in compliance with the License.

--- a/Thorfile
+++ b/Thorfile
@@ -1,5 +1,0 @@
-# encoding: utf-8
-
-require 'bundler'
-require 'bundler/setup'
-require 'berkshelf/thor'

--- a/metadata.json
+++ b/metadata.json
@@ -1,10 +1,10 @@
 {
   "name": "coopr",
-  "description": "Installs/Configures Coopr",
-  "long_description": "# coopr cookbook\n\n[![Cookbook Version](http://img.shields.io/cookbook/v/coopr.svg)](https://supermarket.getchef.com/cookbooks/coopr)\n[![Build Status](http://img.shields.io/travis/caskdata/coopr_cookbook.svg)](http://travis-ci.org/caskdata/coopr_cookbook)\n\n## Requirements\n\n* Oracle Java JDK 6+ (JDK 7 provided by `java` cookbook)\n\n## Optional dependencies\n\n* ZooKeeper (provided by `hadoop` cookbook)\n* JDBC-compatible database\n\n# Usage\n\n# Attributes\n\n* `['coopr']['conf_dir']` - The directory used inside `/etc/coopr` and used via the alternatives system. Default `conf.chef`\n* `['coopr']['repo']['url']` - Specifies URL for fetching packages\n* `['coopr']['repo']['components']` - Repository components to use for APT repositories\n\n# Recipes\n\n* `config` - Configures all services\n* `default` - Runs `config` and `repo` recipes\n* `fullstack` - Installs all packages and services on a single node\n* `provisioner` - Installs the `coopr-provisioner` package and service\n* `repo` - Sets up package manager repositories for coopr packages\n* `server` - Installs the `coopr-server` package and service\n* `ui` - Installs the `coopr-ui` package and service\n\n# Author\n\nAuthor:: Cask Data, Inc. (<ops@cask.co>)\n\n# Testing\n\nThis cookbook requires the `vagrant-omnibus` and `vagrant-berkshelf` Vagrant plugins to be installed.\n\n# License\n\nLicensed under the Apache License, Version 2.0 (the \"License\"); you may not use this software except in compliance with the License. You may obtain a copy of the License at\n\nhttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.\n",
-  "maintainer": "Cask",
+  "description": "Installs/Configures Coopr (CLI, Provisioner, Server and UI)",
+  "long_description": "# coopr cookbook\n\n[![Cookbook Version](http://img.shields.io/cookbook/v/coopr.svg)](https://supermarket.getchef.com/cookbooks/coopr)\n[![Apache License 2.0](http://img.shields.io/badge/license-apache%202.0-green.svg)](http://opensource.org/licenses/Apache-2.0)\n[![Build Status](http://img.shields.io/travis/caskdata/coopr_cookbook.svg)](http://travis-ci.org/caskdata/coopr_cookbook)\n[![Code Climate](https://codeclimate.com/github/caskdata/coopr_cookbook/badges/gpa.svg)](https://codeclimate.com/github/caskdata/coopr_cookbook)\n\n## Requirements\n\n* Oracle Java JDK 6+ (JDK 7 provided by `java` cookbook)\n\n## Optional dependencies\n\n* ZooKeeper (provided by `hadoop` cookbook)\n* JDBC-compatible database (MySQL, PostgreSQL, Oracle DB)\n* JDBC driver JARs\n\n## Usage\n\nThis cookbook is designed to install [Coopr](http://coopr.io) using the built-in ZooKeeper and Derby. A full installation\nsimply needs the `coopr::fullstack` recipe to be included in your server's run_list.\n\n### Attributes\n\n* `['coopr']['conf_dir']` - The directory used inside `/etc/coopr` and used via the alternatives system. Default `conf.chef`\n* `['coopr']['repo']['yum_repo_url']` - Specifies URL for fetching RPM packages via YUM\n* `['coopr']['repo']['apt_repo_url']` - Specifies URL for fetching DEB packages via APT\n* `['coopr']['repo']['apt_components']` - Repository components to use for APT repositories\n\n### Recipes\n\n* `cli` - Installs the `coopr-cli` package\n* `config` - Configures all services\n* `default` - Runs `config` and `repo` recipes\n* `fullstack` - Installs all packages and services on a single node\n* `provisioner` - Installs the `coopr-provisioner` package and service\n* `repo` - Sets up package manager repositories for coopr packages\n* `server` - Installs the `coopr-server` package and service\n* `ui` - Installs the `coopr-ui` package and service\n\n## Author\n\nAuthor:: Cask Data, Inc. (<ops@cask.co>)\n\n## License\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this software except in compliance with the License.\nYou may obtain a copy of the License at\n\nhttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n",
+  "maintainer": "Cask Data, Inc.",
   "maintainer_email": "ops@cask.co",
-  "license": "All rights reserved",
+  "license": "Apache-2.0",
   "platforms": {
     "amazon": ">= 0.0.0",
     "centos": ">= 0.0.0",
@@ -41,5 +41,19 @@
   "recipes": {
 
   },
-  "version": "0.2.0"
+  "version": "0.3.0",
+  "source_url": "https://github.com/caskdata/coopr_cookbook",
+  "issues_url": "https://issues.cask.co/browse/COOK/component/10604",
+  "privacy": false,
+  "chef_versions": [
+    [
+      ">= 11"
+    ]
+  ],
+  "ohai_versions": [
+
+  ],
+  "gems": [
+
+  ]
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,10 @@
 name             'coopr'
-maintainer       'Cask'
+maintainer       'Cask Data, Inc.'
 maintainer_email 'ops@cask.co'
-license          'Apache 2.0'
-description      'Installs/Configures Coopr'
+license          'Apache-2.0'
+description      'Installs/Configures Coopr (CLI, Provisioner, Server and UI)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.0'
+version          '0.3.0'
 
 %w(apt java yum).each do |cb|
   depends cb
@@ -16,3 +16,4 @@ end
 
 source_url 'https://github.com/caskdata/coopr_cookbook' if respond_to?(:source_url)
 issues_url 'https://issues.cask.co/browse/COOK/component/10604' if respond_to?(:issues_url)
+chef_version '>= 11' if respond_to?(:chef_version)


### PR DESCRIPTION
Includes:

- Fix `provisioner.server.uri` for Coopr 0.9.9+ ( Issue: #8 )
- Testing updates ( Issues: #9 #11 #16 )
- Add `coopr::cli` recipe ( Issues: #10 #12 #13 )
- Update README, LICENSE, metadata ( Issues: #14 #15 [COOK-32](https://issues.cask.co/browse/COOK-32) )
- Add `amazon` platform_family for Chef 13 ( Issues: #17 [COOK-123](https://issues.cask.co/browse/COOK-123) )