### PR TITLE
Support newer Ubuntu versions

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -20,9 +20,15 @@
 case node['platform_family']
 when 'debian'
   include_recipe 'apt'
+  codename = node['lsb']['codename']
+  case codename
+  when 'raring', 'saucy', 'trusty', 'utopic', 'vivid', 'wily', 'xenial', 'wheezy', 'jessie', 'stretch'
+    codename = 'precise'
+    Chef::Log.warn('Overriding repository distribution to Precise')
+  end
   apt_repository 'coopr' do
     uri node['coopr']['repo']['apt_repo_url']
-    distribution node['lsb']['codename']
+    distribution codename
     components node['coopr']['repo']['apt_components']
     action :add
     arch 'amd64'


### PR DESCRIPTION
Override the codename of newer Ubuntu versions and Debian releases
to precise, to match the Coopr repository. This was lifted from
the CDAP cookbook.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>